### PR TITLE
add flag to keep/drop incoming timestamp in the received document; ad…

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A GELF compatible input for [Fluentd](http://www.fluentd.org/).
 
 ### Configuration
 
-Accept GELF encoded messages over UDP
+Accept GELF encoded messages over UDP or TCP
 
 ```
 <source>
@@ -17,9 +17,38 @@ Accept GELF encoded messages over UDP
   tag example.gelf
   bind 127.0.0.1
   port 12201
+  # protocol_type            tcp   ##  (defaults to udp) 
+  # trust_client_timestamp   false ##  (defaults to true)
+  # client_timestamp_to_i    true  ##  (defaults to false)
+  # remove_timestamp_record  false ##  (defaults to true)
 </source>
 
 <match example.gelf>
-  type stdout
+  @type file
+  <format>
+    @type out_file
+    time_type string
+    time_format '%Y-%m-%dT%H:%M:%S.%N %z'
+  </format>
+  path /tmp/output
 </match>
+
 ```
+
+### Configuration flags
+  * protocol_type   
+    * udp
+    * tcp
+
+  * trust_client_timestamp (default: true)
+    * true  (use client provided timestamp for fluent metadata if it exists)
+    * false (ignore client provided timestamp for fluent metadata)
+
+    * client_timestamp_to_i (default: false) (ignored if trust_client_timestamp is false)
+      * true  (truncate client provided timestamp to only time_t with no added resolution)
+      * false (retain full client provided resolution)
+
+    * remove_timestamp_record (default: true) (ignored if trust_client_timestamp is false)
+      * true  (remove original timestamp record from client provided document)
+      * false (retain original record and set fluent metadata time
+

--- a/test/plugin/test_in_gelf.rb
+++ b/test/plugin/test_in_gelf.rb
@@ -60,7 +60,6 @@ class GelfInputTest < Test::Unit::TestCase
       assert_equal tests.length, emits.length, 'missing emitted events'
       emits.each_index { |i|
         assert_equal 'gelf', emits[i][0]
-        assert_equal tests[i][:timestamp].to_f, emits[i][1] unless tests[i][:timestamp].nil?
         assert_equal tests[i][:short_message], emits[i][2]['short_message']
         assert_equal tests[i][:full_message], emits[i][2]['full_message']
       }


### PR DESCRIPTION
- new flag to keep or drop timestamp from received record
- new flag to use timestamp from client as time for fluent metadata (used for buffer names and such)
- flag to use full resolution of client offered event or truncate to nearest second
- update parsing of timestamp to allow for proper creation of time_t + nsec resolution events
- 